### PR TITLE
feat(添加 README 和 docker-compose 的提交):

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
 # zanePerfor一款完整、高性能、高可用的前端性能监控和统计平台
+## docker 安装配置环境
+1. 安装并保证有 docker-compose 的环境
+2. 修改 start-docker-compose.sh 里的 hostIP 为外网 IP
+⚠️ 不能是 `127.0.0.1` 或 `localhost`  
+
+3. docker-compose 启动方式
+> 方式一：
+```sh
+# 项目所在目录
+./start-docker-compose.sh
+```
+
+> 方式二
+```sh
+export hostIP='自己的外网IP' && docker-compose up -d --build
+```
+
+4. 启动 web 开发环境
+```sh
+npm run dev
+```
+
+5. 启动 web start 环境
+⚠️ 修改 config/config.prod.js 里的 redis 配置
+```sh
+npm start 
+```
+
 ## 开发功能进度说明
 >  * 集成框架选型及其相关配置（已完成）
 >  * 主重数据库相关配置开发（已完成）

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -7,7 +7,7 @@ module.exports = () => {
 
     config.keys = '_123456789';
 
-    config.middleware = [ ];
+    config.middleware = [];
 
     config.name = '性能监控系统';
 
@@ -18,9 +18,6 @@ module.exports = () => {
     // 务必修改config.debug = true;
     config.session_secret = 'node_performance_secret';
 
-    // 用于安全校验和回调域名根路径 开发路径域名（必填）
-    config.origin = 'http://127.0.0.1:7001';
-
     // 集群配置（一般默认即可）
     config.cluster = {
         listen: {
@@ -29,6 +26,9 @@ module.exports = () => {
             ip: address.ip(),
         },
     };
+
+    // 用于安全校验和回调域名根路径 开发路径域名（必填）
+    config.origin = `http://127.0.0.1:${config.cluster.listen.port}`;
 
     // 用户登录态持续时间 1 天
     config.user_login_timeout = 86400;
@@ -141,9 +141,9 @@ module.exports = () => {
     // shell重启
     config.shell_restart = {
         // mongodb重启shell,如果mongodb进程kill了，请求不了数据库时重启（可选填）
-        mongodb: [ path.resolve(__dirname, '../mongodb-restart.sh') ],
+        mongodb: [path.resolve(__dirname, '../mongodb-restart.sh')],
         // node.js服务重启shell,mongodb重启时，数据库连接池有可能会断，这时需要重启服务
-        servers: [ path.resolve(__dirname, '../servers-restart.sh') ],
+        servers: [path.resolve(__dirname, '../servers-restart.sh')],
     };
 
     // 百度地图api key
@@ -156,14 +156,14 @@ module.exports = () => {
     config.github = {
         client_id: 'xxxxxx',
         client_secret: 'xxxxxx',
-        scope: [ 'user' ],
+        scope: ['user'],
     };
 
     // 新浪微博 login
     config.weibo = {
         client_id: 'xxxxxx', // 微博的App Key
         client_secret: 'xxxxxx', // 微博的App Secret
-        scope: [ 'all' ],
+        scope: ['all'],
     };
 
     // wechat login
@@ -247,7 +247,7 @@ module.exports = () => {
     };
 
     config.security = {
-        domainWhiteList: [ 'http://127.0.0.1:18090' ],
+        domainWhiteList: ['http://127.0.0.1:18090'],
         csrf: {
             enable: false,
             ignore: '/api/v1/report/**',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "0.1" 
+services:
+  redis: 
+    image: redis:3.2
+    ports: 
+      - "6379:6379"
+  mongo:
+    image: mongo:3.4
+    ports: 
+      - "27017:27017"
+  # 源 https://raw.githubusercontent.com/wurstmeister/kafka-docker/master/docker-compose.yml
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.12-2.0.1
+    ports:
+      - "9092:9092"
+    environment:
+      # your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
+      KAFKA_ADVERTISED_HOST_NAME: ${hostIP}
+      # KAFKA_ZOOKEEPER_CONNECT: zookeeper:2180
+      KAFKA_ZOOKEEPER_CONNECT: ${hostIP}:2181
+  

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -1,0 +1,2 @@
+export hostIP='自己的外网IP'
+docker-compose up -d --build


### PR DESCRIPTION
1. 添加了 docker-compse 的启动执行环境 
包括 redis - mongodb - zookeeper - kafka

2. 解决 config.default.js 配置小bug
该bug重现环境：如果启动的web不是默认的 7001，会被 origin 控制，登陆成功会重定向回到登陆页面；

3. 更改了 README.md 文件