### PR TITLE
增加对ldap的支持

### DIFF
--- a/app/service/ldap.js
+++ b/app/service/ldap.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const ldap = require('ldapjs');
+const Service = require('egg').Service;
+
+class LdapService extends Service {
+    constructor(ctx) {
+        super(ctx);
+        const { server, ou, dc } = ctx.app.config.ldap;
+        this.config = { ou, dc };
+        this.client = ldap.createClient({
+            url: server,
+        });
+    }
+    search(userName) {
+        const { ou, dc } = this.config;
+        return new Promise((resolve, reject) => {
+            const str = `cn=${userName}, ou=${ou}, dc=${dc}, dc=com`;
+            this.client.search(str, {}, (err, res) => {
+                if (err) {
+                    this.ctx.logger.error(`ldap search error:${err.stack}`);
+                    reject(err);
+                }
+                res.on('searchEntry', entry => {
+                    resolve(entry.object);
+                });
+                res.on('error', err => {
+                    this.ctx.logger.error(`ldap search searchEntry error:${err.stack}`);
+                    reject(err);
+                });
+                res.on('end', err => {
+                    if (err) reject(err);
+                });
+            });
+        });
+    }
+}
+
+module.exports = LdapService;

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -167,6 +167,14 @@ module.exports = () => {
         scope: [ 'user' ], // 表示只获取用户信息
     };
 
+    // ldap
+    config.ldap = {
+        server: 'ldap://xxx', // ldap服务器地址
+        ou: 'xx', // ou
+        dc: 'xx', // dc, 非com的另外一层的dc，例如 dc=foobar,dc=com, 这里填 foobar
+        isLdap: false, // 是否采用ldap;
+    };
+
     // 新浪微博 login
     config.weibo = {
         client_id: 'xxxxxx', // 微博的App Key

--- a/config/config.prod.js
+++ b/config/config.prod.js
@@ -19,6 +19,14 @@ module.exports = () => {
         scope: [ 'user' ],
     };
 
+    // ldap
+    config.ldap = {
+        server: 'ldap://xxx', // ldap服务器地址
+        ou: 'xx', // ou
+        dc: 'xx', // dc, 非com的另外一层的dc，例如 dc=foobar,dc=com, 这里填 foobar
+        isLdap: false, // 是否采用ldap;
+    };
+
     // 新浪微博 login
     config.weibo = {
         client_id: 'xxxxxx', // 微博的App Key

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "egg-redis": "^2.0.0",
     "egg-router-plus": "^1.3.0",
     "egg-scripts": "^2.10.0",
-    "egg-socket.io": "^4.1.4"
+    "egg-socket.io": "^4.1.4",
+    "ldapjs": "^1.0.2"
   },
   "devDependencies": {
     "autod": "^3.0.1",


### PR DESCRIPTION
 问题#12 ，增加对ldap的支持，
实现思路: config增加ldap相关设置, isLdap 是否采用ldap;  
如果采用ldap,则在用户登录时判断输入的用户名密码在库里是否有对应的用户,如果有，则对应登录,如果没有,则ldap 获取用户信息, 拿到用户登录信息后，用用户名+密码在数据库里添加用户，然后继续走后面的流程。

这针对全国统一的saas平台会有窜用户的问题,但对于私有的部署应该是可以的